### PR TITLE
Added libgles2 as dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY ui.patch /tmp
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y binutils ca-certificates curl dbus fonts-noto-cjk locales libegl1 openbox patch python3-numpy software-properties-common tigervnc-standalone-server tigervnc-tools tzdata xz-utils --no-install-recommends
+    apt-get install -y binutils ca-certificates curl dbus fonts-noto-cjk locales libegl1 libgles2-mesa-dev openbox patch python3-numpy software-properties-common tigervnc-standalone-server tigervnc-tools tzdata xz-utils --no-install-recommends
 
 RUN add-apt-repository ppa:nicotine-team/stable && \
     apt-get update && \


### PR DESCRIPTION
Missing `libgles2-mesa-dev` would trigger a memory leak.

Error for reference:
```bash
Extension modules: gi._gi, cairo._cairo, gi._gi_cairo (total: 3)
[02/04/25 17:45:30] Loading Python 3.12.3
[02/04/25 17:45:30] Loading Nicotine+ 3.3.7
libEGL warning: DRI3: Screen seems not DRI3 capable
libEGL warning: DRI3: Screen seems not DRI3 capable
MESA: error: ZINK: vkCreateInstance failed (VK_ERROR_INCOMPATIBLE_DRIVER)
libEGL warning: egl: failed to create dri2 screen
[02/04/2025 05:45:30 PM] Loading GTK 4.14.2

(org.nicotine_plus.Nicotine:1178): Gtk-WARNING **: 17:45:30.973: Unable to acquire session bus: Failed to execute child process “dbus-launch” (No such file or directory)
[02/04/2025 05:45:31 PM] Loading plugin system
[02/04/2025 05:45:31 PM] Loaded plugin Nicotine+ Commands
Couldn't open libGLESv2.so.2: libGLESv2.so.2: cannot open shared object file: No such file or directory
Fatal Python error: Aborted
```